### PR TITLE
Fix channel index offset

### DIFF
--- a/experimentA/renderingsettings/SPM00_TM000136_CM00_CM01_CHN01.klb.yml
+++ b/experimentA/renderingsettings/SPM00_TM000136_CM00_CM01_CHN01.klb.yml
@@ -1,5 +1,6 @@
 ---
+version: 2
 channels:
-  0: {active: true, color: '808080', end: 752.0, label: mKate2-nls,
+  1: {active: true, color: '808080', end: 752.0, label: mKate2-nls,
       max: 65535.0, min: 0.0, start: 0.0}
 greyscale: true

--- a/experimentA/renderingsettings/SPM00_TM000136_CM00_CM01_CHN01_xyProjection.klb.yml
+++ b/experimentA/renderingsettings/SPM00_TM000136_CM00_CM01_CHN01_xyProjection.klb.yml
@@ -1,5 +1,6 @@
 ---
+version: 2
 channels:
-  0: {active: true, color: '808080', end: 1658.0, label: mKate2-nls,
+  1: {active: true, color: '808080', end: 1658.0, label: mKate2-nls,
       max: 65535.0, min: 0.0, start: 0.0}
 greyscale: true

--- a/experimentA/renderingsettings/SPM00_TM000136_CM00_CM01_CHN01_xzProjection.klb.yml
+++ b/experimentA/renderingsettings/SPM00_TM000136_CM00_CM01_CHN01_xzProjection.klb.yml
@@ -1,5 +1,6 @@
 ---
+version: 2
 channels:
-  0: {active: true, color: '808080', end: 1280.0, label: mKate2-nls,
+  1: {active: true, color: '808080', end: 1280.0, label: mKate2-nls,
       max: 65535.0, min: 0.0, start: 0.0}
 greyscale: true

--- a/experimentA/renderingsettings/SPM00_TM000136_CM00_CM01_CHN01_yzProjection.klb.yml
+++ b/experimentA/renderingsettings/SPM00_TM000136_CM00_CM01_CHN01_yzProjection.klb.yml
@@ -1,5 +1,6 @@
 ---
+version: 2
 channels:
-  0: {active: true, color: '808080', end: 1315.0, label: mKate2-nls,
+  1: {active: true, color: '808080', end: 1315.0, label: mKate2-nls,
       max: 65535.0, min: 0.0, start: 0.0}
 greyscale: true

--- a/experimentA/renderingsettings/SPM00_TM000184_CM00_CM01_CHN00.klb.yml
+++ b/experimentA/renderingsettings/SPM00_TM000184_CM00_CM01_CHN00.klb.yml
@@ -1,5 +1,6 @@
 ---
+version: 2
 channels:
-  0: {active: true, color: '808080', end: 800.0, label: H2B-eGFP,
+  1: {active: true, color: '808080', end: 800.0, label: H2B-eGFP,
       max: 65535.0, min: 0.0, start: 0.0}
 greyscale: true

--- a/experimentA/renderingsettings/SPM00_TM000184_CM00_CM01_CHN00_xyProjection.klb.yml
+++ b/experimentA/renderingsettings/SPM00_TM000184_CM00_CM01_CHN00_xyProjection.klb.yml
@@ -1,5 +1,6 @@
 ---
+version: 2
 channels:
-  0: {active: true, color: '808080', end: 2188.0, label: H2B-eGFP,
+  1: {active: true, color: '808080', end: 2188.0, label: H2B-eGFP,
       max: 65535.0, min: 0.0, start: 0.0}
 greyscale: true

--- a/experimentA/renderingsettings/SPM00_TM000184_CM00_CM01_CHN00_xzProjection.klb.yml
+++ b/experimentA/renderingsettings/SPM00_TM000184_CM00_CM01_CHN00_xzProjection.klb.yml
@@ -1,5 +1,6 @@
 ---
+version: 2
 channels:
-  0: {active: true, color: '808080', end: 2112.0, label: H2B-eGFP,
+  1: {active: true, color: '808080', end: 2112.0, label: H2B-eGFP,
       max: 65535.0, min: 0.0, start: 0.0}
 greyscale: true

--- a/experimentA/renderingsettings/SPM00_TM000184_CM00_CM01_CHN00_yzProjection.klb.yml
+++ b/experimentA/renderingsettings/SPM00_TM000184_CM00_CM01_CHN00_yzProjection.klb.yml
@@ -1,5 +1,6 @@
 ---
+version: 2
 channels:
-  0: {active: true, color: '808080', end: 2100.0, label: H2B-eGFP,
+  1: {active: true, color: '808080', end: 2100.0, label: H2B-eGFP,
       max: 65535.0, min: 0.0, start: 0.0}
 greyscale: true

--- a/experimentA/renderingsettings/SPM00_TM000319_CM00_CM01_CHN00.klb.yml
+++ b/experimentA/renderingsettings/SPM00_TM000319_CM00_CM01_CHN00.klb.yml
@@ -1,5 +1,6 @@
 ---
+version: 2
 channels:
-  0: {active: true, color: '808080', end: 608.0, label: mKate2-nls,
+  1: {active: true, color: '808080', end: 608.0, label: mKate2-nls,
       max: 65535.0, min: 0.0, start: 0.0}
 greyscale: true

--- a/experimentA/renderingsettings/SPM00_TM000319_CM00_CM01_CHN00_xyProjection.klb.yml
+++ b/experimentA/renderingsettings/SPM00_TM000319_CM00_CM01_CHN00_xyProjection.klb.yml
@@ -1,5 +1,6 @@
 ---
+version: 2
 channels:
-  0: {active: true, color: '808080', end: 1809.0, label: mKate2-nls,
+  1: {active: true, color: '808080', end: 1809.0, label: mKate2-nls,
       max: 65535.0, min: 0.0, start: 0.0}
 greyscale: true

--- a/experimentA/renderingsettings/SPM00_TM000319_CM00_CM01_CHN00_xzProjection.klb.yml
+++ b/experimentA/renderingsettings/SPM00_TM000319_CM00_CM01_CHN00_xzProjection.klb.yml
@@ -1,5 +1,6 @@
 ---
+version: 2
 channels:
-  0: {active: true, color: '808080', end: 1780.0, label: mKate2-nls,
+  1: {active: true, color: '808080', end: 1780.0, label: mKate2-nls,
       max: 65535.0, min: 0.0, start: 0.0}
 greyscale: true

--- a/experimentA/renderingsettings/SPM00_TM000319_CM00_CM01_CHN00_yzProjection.klb.yml
+++ b/experimentA/renderingsettings/SPM00_TM000319_CM00_CM01_CHN00_yzProjection.klb.yml
@@ -1,5 +1,6 @@
 ---
+version: 2
 channels:
-  0: {active: true, color: '808080', end: 1930.0, label: mKate2-nls,
+  1: {active: true, color: '808080', end: 1930.0, label: mKate2-nls,
       max: 65535.0, min: 0.0, start: 0.0}
 greyscale: true

--- a/experimentA/renderingsettings/SPM00_TM000512_CM00_CM01_CHN01.klb.yml
+++ b/experimentA/renderingsettings/SPM00_TM000512_CM00_CM01_CHN01.klb.yml
@@ -1,7 +1,8 @@
 ---
+version: 2
 channels:
-  0: {active: true, color: 00FF00, end: 1093.0, label: H2B-eGFP, max: 65535.0,
+  1: {active: true, color: 00FF00, end: 1093.0, label: H2B-eGFP, max: 65535.0,
       min: 0.0, start: 0.0}
-  1: {active: true, color: FF0000, end: 439.0, label: 'myr-tdTomato',
+  2: {active: true, color: FF0000, end: 439.0, label: 'myr-tdTomato',
       max: 65535.0, min: 0.0, start: 0.0}
 greyscale: false

--- a/experimentA/renderingsettings/SPM00_TM000512_CM00_CM01_CHN01_xyProjection.klb.yml
+++ b/experimentA/renderingsettings/SPM00_TM000512_CM00_CM01_CHN01_xyProjection.klb.yml
@@ -1,7 +1,8 @@
 ---
+version: 2
 channels:
-  0: {active: true, color: 00FF00, end: 2093.0, label: H2B-eGFP, max: 65535.0,
+  1: {active: true, color: 00FF00, end: 2093.0, label: H2B-eGFP, max: 65535.0,
       min: 0.0, start: 0.0}
-  1: {active: true, color: FF0000, end: 899.0, label: 'myr-tdTomato',
+  2: {active: true, color: FF0000, end: 899.0, label: 'myr-tdTomato',
       max: 65535.0, min: 0.0, start: 0.0}
 greyscale: false

--- a/experimentA/renderingsettings/SPM00_TM000512_CM00_CM01_CHN01_xzProjection.klb.yml
+++ b/experimentA/renderingsettings/SPM00_TM000512_CM00_CM01_CHN01_xzProjection.klb.yml
@@ -1,7 +1,8 @@
 ---
+version: 2
 channels:
-  0: {active: true, color: 00FF00, end: 2293.0, label: H2B-eGFP, max: 65535.0,
+  1: {active: true, color: 00FF00, end: 2293.0, label: H2B-eGFP, max: 65535.0,
       min: 0.0, start: 0.0}
-  1: {active: true, color: FF0000, end: 1029.0, label: 'myr-tdTomato',
+  2: {active: true, color: FF0000, end: 1029.0, label: 'myr-tdTomato',
       max: 65535.0, min: 0.0, start: 0.0}
 greyscale: false

--- a/experimentA/renderingsettings/SPM00_TM000512_CM00_CM01_CHN01_yzProjection.klb.yml
+++ b/experimentA/renderingsettings/SPM00_TM000512_CM00_CM01_CHN01_yzProjection.klb.yml
@@ -1,7 +1,8 @@
 ---
+version: 2
 channels:
-  0: {active: true, color: 00FF00, end: 2393.0, label: H2B-eGFP, max: 65535.0,
+  1: {active: true, color: 00FF00, end: 2393.0, label: H2B-eGFP, max: 65535.0,
       min: 0.0, start: 0.0}
-  1: {active: true, color: FF0000, end: 1079.0, label: 'myr-tdTomato',
+  2: {active: true, color: FF0000, end: 1079.0, label: 'myr-tdTomato',
       max: 65535.0, min: 0.0, start: 0.0}
 greyscale: false


### PR DESCRIPTION
**This is metadata repository only, doesn't affect idr0044 on IDR**

The channel index of the rendering settings should be 1-based. It was 0-based because I used modified version of the cli-render plugin at that time. Also added a version field so that they are compatible with https://github.com/ome/omero-cli-render/pull/15 (ie. do not merge until the omero-cli-render PR is merged).
